### PR TITLE
fix #1

### DIFF
--- a/src/FilesystemCachePool.php
+++ b/src/FilesystemCachePool.php
@@ -12,6 +12,7 @@
 namespace Cache\Adapter\Filesystem;
 
 use Cache\Adapter\Common\AbstractCachePool;
+use Cache\Adapter\Common\Exception\InvalidArgumentException;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use Psr\Cache\CacheItemInterface;
@@ -74,12 +75,17 @@ class FilesystemCachePool extends AbstractCachePool
     }
 
     /**
-     * @param $key
+     * @param string $key
      *
-     * @return mixed
+     * @return string
+     * @throws InvalidArgumentException
      */
     private function getFilePath($key)
     {
-        return sprintf('%s/%s', self::CACHE_PATH, urlencode(base64_encode($key)));
+        if (!preg_match('|^[a-zA-Z0-9_\.: ]+$|', $key)) {
+            throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid keys must match [a-zA-Z0-9_\.:].', $key));
+        }
+
+        return sprintf('%s/%s', self::CACHE_PATH, $key);
     }
 }

--- a/tests/FilesystemCachePoolTest.php
+++ b/tests/FilesystemCachePoolTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Cache\Adapter\Filesystem\tests;
+
+use Cache\Adapter\Filesystem\FilesystemCachePool;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Psr\Cache\InvalidArgumentException
+     */
+    public function testInvalidKey()
+    {
+        $pool = new FilesystemCachePool(new Filesystem(new Local(__DIR__.'/')));
+
+        $pool->getItem('test%string');
+    }
+}


### PR DESCRIPTION
Since Flysystem removes "any kind of funky unicode whitespace" we might run into a situation like this: 

``` php
// Empty cache
$item = $pool->getItem('foo[funky unicode]bar");
$item->set('value');
$pool->save($item);

$pool->hasItem('foobar"); // True
```

This PR prevents that situation. 

This will fix #1
