### PR TITLE
Updated file name to allow keys to be written to disc.

### DIFF
--- a/FilesystemCachePool.php
+++ b/FilesystemCachePool.php
@@ -134,11 +134,15 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
      */
     private function getFilePath($key)
     {
-        if (!preg_match('|^[a-zA-Z0-9_\.! ]+$|', $key)) {
-            throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid keys must match [a-zA-Z0-9_\.! ].', $key));
+
+        //make the key a safe filename
+        $filename = str_replace('=', '_', base64_encode($key));
+
+        if (!preg_match('|^[a-zA-Z0-9_\.! ]+$|', $filename)) {
+            throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid filenames must match [a-zA-Z0-9_\.! ].', $filename));
         }
 
-        return sprintf('%s/%s', $this->folder, $key);
+        return sprintf('%s/%s', $this->folder, $filename);
     }
 
     /**

--- a/Tests/FilesystemCachePoolTest.php
+++ b/Tests/FilesystemCachePoolTest.php
@@ -18,31 +18,25 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
 {
     use CreatePoolTrait;
 
-    /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
-     */
-    public function testInvalidKey()
-    {
-        $pool = $this->createCachePool();
-
-        $pool->getItem('test%string')->get();
-    }
 
     public function testCleanupOnExpire()
     {
+        $cacheKey = 'test_ttl_null';
+        $cacheFilename = $filename = str_replace('=', '_', base64_encode($cacheKey));
+
         $pool = $this->createCachePool();
 
-        $item = $pool->getItem('test_ttl_null');
+        $item = $pool->getItem($cacheKey);
         $item->set('data');
         $item->expiresAt(new \DateTime('now'));
         $pool->save($item);
-        $this->assertTrue($this->getFilesystem()->has('cache/test_ttl_null'));
+        $this->assertTrue($this->getFilesystem()->has('cache/' . $cacheFilename));
 
         sleep(1);
 
-        $item = $pool->getItem('test_ttl_null');
+        $item = $pool->getItem($cacheKey);
         $this->assertFalse($item->isHit());
-        $this->assertFalse($this->getFilesystem()->has('cache/test_ttl_null'));
+        $this->assertFalse($this->getFilesystem()->has('cache/' . $cacheFilename));
     }
 
     public function testChangeFolder()


### PR DESCRIPTION
The problem was that some cache keys are rejected by `getFilePath` as they are not valid file names. The key should have been rejected earlier when adding to the cache. To solve this I have translated the cache key to a safe filename using base64 encoding and replacing the = with _ (underscore). This means that any cache key can be written to a file.

Guy
