### PR TITLE
add "-" to file path check

### DIFF
--- a/FilesystemCachePool.php
+++ b/FilesystemCachePool.php
@@ -141,8 +141,8 @@ class FilesystemCachePool extends AbstractCachePool
      */
     private function getFilePath($key)
     {
-        if (!preg_match('|^[a-zA-Z0-9_\.! ]+$|', $key)) {
-            throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid filenames must match [a-zA-Z0-9_\.! ].', $key));
+        if (!preg_match('|^[a-zA-Z0-9_\.\-! ]+$|', $key)) {
+            throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid filenames must match [a-zA-Z0-9_\.\-! ].', $key));
         }
 
         return sprintf('%s/%s', $this->folder, $key);


### PR DESCRIPTION
I use it from PhpSpreadsheet.

Because PhpSpreadsheet will internally hyphenate the cache's path, an InvalidArgumentException will occur.
